### PR TITLE
Update for latest release of yuin/goldmark

### DIFF
--- a/ansi/renderer.go
+++ b/ansi/renderer.go
@@ -73,7 +73,7 @@ func (r *ANSIRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(astext.KindFootnote, r.renderNode)
 	reg.Register(astext.KindFootnoteList, r.renderNode)
 	reg.Register(astext.KindFootnoteLink, r.renderNode)
-	reg.Register(astext.KindFootnoteBackLink, r.renderNode)
+	reg.Register(astext.KindFootnoteBacklink, r.renderNode)
 
 	// checkboxes
 	reg.Register(astext.KindTaskCheckBox, r.renderNode)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/muesli/reflow v0.2.0
 	github.com/muesli/termenv v0.7.4
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/yuin/goldmark v1.2.1
+	github.com/yuin/goldmark v1.3.1
 	github.com/yuin/goldmark-emoji v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/yuin/goldmark v1.2.1 h1:ruQGxdhGHe7FWOJPT0mKs5+pD2Xs1Bm/kdGlHO04FmM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.1 h1:eVwehsLsZlCJCwXyGLgg+Q4iFWE/eTIMG0e8waCmm/I=
+github.com/yuin/goldmark v1.3.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=


### PR DESCRIPTION
https://github.com/yuin/goldmark/commit/9e0189df270cb443c204b51e89e2b0749b98370c
broke backwards compatibility by renaming exported structs without a
bump of the module's major version.

This commit updates glamour to use goldmark's new API.